### PR TITLE
Fix var syntax highlighting

### DIFF
--- a/witcherscript/grammar.json
+++ b/witcherscript/grammar.json
@@ -104,7 +104,7 @@
 			]
 		},
 		{
-			"begin": "(var)\\s*",
+			"begin": "\\b(var)\\b\\s*",
 			"beginCaptures": {
 				"1": {
 					"name": "storage.type.ws"


### PR DESCRIPTION
`var` should not be recognized as keyword mid variable name.

![image](https://user-images.githubusercontent.com/37928424/82760362-552f5300-9df3-11ea-9d62-6645758dccdb.png)
